### PR TITLE
Do not use Whoops if YII_DEBUG is false or if errorAction is set and exception is CHttpException

### DIFF
--- a/WhoopsErrorHandler.php
+++ b/WhoopsErrorHandler.php
@@ -71,6 +71,10 @@ class WhoopsErrorHandler extends CErrorHandler {
 	 * @param CErrorEvent $event
 	 */
 	protected function handleError($event) {
+		if (!YII_DEBUG) {
+			parent::handleError($event);
+			return;
+		}
 		$this->disableLogRoutes();
 		$this->whoops->handleError($event->code, $event->message, $event->file, $event->line);
 	}
@@ -80,6 +84,10 @@ class WhoopsErrorHandler extends CErrorHandler {
 	 * @param Exception $exception
 	 */
 	protected function handleException($exception) {
+		if ($exception instanceof CHttpException && $this->errorAction!==null || !YII_DEBUG) {
+			parent::handleException($exception);
+			return;
+		}
 		$this->disableLogRoutes();
 		$this->whoops->handleException($exception);
 	}


### PR DESCRIPTION
The latter allows you to work on and test your error action in development (e.g. 404 page)
The former is in case you forget to set a different error handler in production, since CErrorHandler will check  YII_DEBUG and won't leak sensitive data.
